### PR TITLE
feat: Cancelar documento por llave

### DIFF
--- a/samples/Sdk.Extras.ConsoleApp/Catalogos/DocumentoSdk.cs
+++ b/samples/Sdk.Extras.ConsoleApp/Catalogos/DocumentoSdk.cs
@@ -179,6 +179,13 @@ public sealed class DocumentoSdk
         _documentoService.Cancelar(documento.CIDDOCUMENTO, "12345678a", "02", "");
     }
 
+    public void CancelarDocumentoPorLlave()
+    {
+        _logger.LogInformation("CancelarDocumentoPorLlave()");
+        var llave = new tLlaveDoc { aCodConcepto = "400", aSerie = "FAP", aFolio = 58 };
+        _documentoService.Cancelar(llave, "12345678A", "02", "");
+    }
+
     public void LogDocumento(Documento documento)
     {
         _logger.LogInformation("Concepto:{Concepto}, Serie:{Serie}, Folio{Folio}, Cliente:{Cliente}, Total:{Total}",

--- a/samples/Sdk.Extras.ConsoleApp/Program.cs
+++ b/samples/Sdk.Extras.ConsoleApp/Program.cs
@@ -1,5 +1,4 @@
-﻿using ARSoftware.Contpaqi.Comercial.Sdk;
-using ARSoftware.Contpaqi.Comercial.Sdk.Extras;
+﻿using ARSoftware.Contpaqi.Comercial.Sdk.Extras;
 using ARSoftware.Contpaqi.Comercial.Sdk.Extras.Interfaces;
 using ARSoftware.Contpaqi.Comercial.Sdk.Extras.Models;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,7 +10,7 @@ using Sdk.Extras.ConsoleApp.Catalogos;
 IHost host = Host.CreateDefaultBuilder()
     .ConfigureServices(collection =>
     {
-        collection.AddContpaqiComercialSdkServices(TipoContpaqiSdk.FacturaElectronica);
+        collection.AddContpaqiComercialSdkServices();
         collection.AddSingleton<ConexionSdk>()
             .AddSingleton<EmpresaSdk>()
             .AddSingleton<ClienteSdk>()

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/Interfaces/IDocumentoService.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/Interfaces/IDocumentoService.cs
@@ -13,6 +13,7 @@ namespace ARSoftware.Contpaqi.Comercial.Sdk.Extras.Interfaces
         tLlaveDoc BuscarSiguienteSerieYFolio(string codigoConcepto);
         void Cancelar(int idDocumento, string contrasenaCertificado);
         void Cancelar(int idDocumento, string contrasenaCertificado, string motivoCancelacion, string uuidRemplazo);
+        void Cancelar(tLlaveDoc tLlaveDocumento, string contrasenaCertificado, string motivoCancelacion, string uuidRemplazo);
         void CancelarAdministrativamente(int idDocumento);
         void CancelarAdministrativamente(string codigoConcepto, string serie, string folio);
         void CancelarAdministrativamente(tLlaveDoc tLlaveDocumento);

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/Services/DocumentoService.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/Services/DocumentoService.cs
@@ -68,6 +68,13 @@ namespace ARSoftware.Contpaqi.Comercial.Sdk.Extras.Services
             _sdk.fCancelaDocumentoConMotivo(motivoCancelacion, uuidRemplazo);
         }
 
+        public void Cancelar(tLlaveDoc tLlaveDocumento, string contrasenaCertificado, string motivoCancelacion, string uuidRemplazo)
+        {
+            _sdk.fBuscaDocumento(ref tLlaveDocumento).ToResultadoSdk(_sdk).ThrowIfError();
+            _sdk.fCancelaDoctoInfo(contrasenaCertificado).ToResultadoSdk(_sdk).ThrowIfError();
+            _sdk.fCancelaDocumentoConMotivo(motivoCancelacion, uuidRemplazo);
+        }
+
         public void CancelarAdministrativamente(int idDocumento)
         {
             _sdk.fBuscarIdDocumento(idDocumento).ToResultadoSdk(_sdk).ThrowIfError();


### PR DESCRIPTION
Este PR agrega un método al servicio de documentos para poder cancelar documentos por llave.

Closes #54 

```csharp
public void Cancelar(tLlaveDoc tLlaveDocumento, string contrasenaCertificado, string motivoCancelacion, string uuidRemplazo)
{
    _sdk.fBuscaDocumento(ref tLlaveDocumento).ToResultadoSdk(_sdk).ThrowIfError();
    _sdk.fCancelaDoctoInfo(contrasenaCertificado).ToResultadoSdk(_sdk).ThrowIfError();
    _sdk.fCancelaDocumentoConMotivo(motivoCancelacion, uuidRemplazo);
}
```
