### PR TITLE
feat: agrega CotizacionDelProveedor a DocumentoModelo

### DIFF
--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/Models/DocumentoModelo.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/Models/DocumentoModelo.cs
@@ -47,6 +47,7 @@ namespace ARSoftware.Contpaqi.Comercial.Sdk.Extras.Models
         public static readonly DocumentoModelo NotaDeVenta = new DocumentoModelo(35, "Nota De Venta");
         public static readonly DocumentoModelo DevolucionSobreNotaDeVenta = new DocumentoModelo(36, "Devolucion Sobre Nota De Venta");
         public static readonly DocumentoModelo AjusteAlCosto = new DocumentoModelo(37, "Ajuste Al Costo");
+        public static readonly DocumentoModelo CotizacionDelProveedor = new DocumentoModelo(38, "Cotización del Proveedor");
 
         public DocumentoModelo()
         {
@@ -110,6 +111,7 @@ namespace ARSoftware.Contpaqi.Comercial.Sdk.Extras.Models
             yield return NotaDeVenta;
             yield return DevolucionSobreNotaDeVenta;
             yield return AjusteAlCosto;
+            yield return CotizacionDelProveedor;
         }
     }
 }


### PR DESCRIPTION
Este PR agrega el registro `CotizacionDelProveedor` a la clase `DocumentoModelo`.

CONTPAQi agrego el documento modelo `Cotización del Proveedor` a la tabla de `admDocumentosModelo`. 

Al listar los conceptos y hacer uso de `DocumentoModelo.FromId` para buscar el documento modelo del concepto este marcaba una Excepcion.

