### PR TITLE
refactor: consolida versiones de todos los projectos a 4.4.0

### DIFF
--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<Version>4.3.0</Version>
+		<Version>4.4.0</Version>
 		<Authors>AR Software</Authors>
 		<Description>Este proyecto extiende el proyecto ARSoftware.Contpaqi.Comercial.Sdk y dispone de varios repositorios y servicios que implementan las diferentes funcionalidades del SDK.</Description>
 		<Copyright>Copyright © AR Software 2022</Copyright>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk/ARSoftware.Contpaqi.Comercial.Sdk.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk/ARSoftware.Contpaqi.Comercial.Sdk.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<Version>4.2.0</Version>
+		<Version>4.4.0</Version>
 		<Authors>AR Software</Authors>
 		<Description>Este proyecto tiene declaradas todas las funciones y clases utilizadas por el SDK de CONTPAQi Comercial, CONTPAQi Adminpaq, y CONTPAQi Factura Electronica.</Description>
 		<Copyright>Copyright © AR Software 2022</Copyright>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/ARSoftware.Contpaqi.Comercial.Sql.Models.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/ARSoftware.Contpaqi.Comercial.Sql.Models.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<Version>3.2.0</Version>
+		<Version>4.4.0</Version>
 		<Authors>AR Software</Authors>
 		<Description>Modelo de las bases de datos de CONTPAQi Comercial version 8.1.1</Description>
 		<Copyright>Copyright © AR Software 2022</Copyright>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<Nullable>disable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<Version>3.3.0</Version>
+		<Version>4.4.0</Version>
 		<Authors>AR Software</Authors>
 		<Description>Entity Framework DbContexts para hacer query las bases de datos de CONTPAQi Comercial</Description>
 		<Copyright>Copyright © AR Software 2022</Copyright>


### PR DESCRIPTION
Este PR consolida las versiones de todos los projectos a la version 4.4.0.

De ahora en adelantes todas las librerías se actualizaran y liberaran al mismo tiempo utilizando la misma version aun si hay librerias donde no hubo cambios.

Las razones para este cambio son:
- Consolidar versiones para saber que todas son compatibles y actualizadas
- Hacer uso de GitHub Release para informar mejor sobre cambios (Release Notes)