### PR TITLE
Corrige error donde no se estaban asignando la tasa de impuesto 2 y 3 en los movimientos

### DIFF
--- a/ARSoftware.Contpaqi.Comercial.sln.DotSettings
+++ b/ARSoftware.Contpaqi.Comercial.sln.DotSettings
@@ -1,6 +1,11 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialMethodWithSinglePart/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialTypeWithSinglePart/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_FOR/@EntryValue">RequiredForMultiline</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_FOREACH/@EntryValue">RequiredForMultiline</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_IFELSE/@EntryValue">RequiredForMultiline</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_WHILE/@EntryValue">RequiredForMultiline</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
 &lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
   &lt;TypePattern DisplayName="Non-reorderable types"&gt;&#xD;

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/Extensions/MovimientoExtensions.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/Extensions/MovimientoExtensions.cs
@@ -108,7 +108,7 @@ public static class MovimientoExtensions
 
         if (movimiento.Impuestos.Impuesto2.Tasa != 0)
         {
-            datosMovimiento.TryAdd(nameof(admMovimientos.CIMPUESTO2),
+            datosMovimiento.TryAdd(nameof(admMovimientos.CPORCENTAJEIMPUESTO2),
                 movimiento.Impuestos.Impuesto2.Tasa.ToString(CultureInfo.InvariantCulture));
         }
 

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/Extensions/MovimientoExtensions.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/Extensions/MovimientoExtensions.cs
@@ -120,7 +120,7 @@ public static class MovimientoExtensions
 
         if (movimiento.Impuestos.Impuesto3.Tasa != 0)
         {
-            datosMovimiento.TryAdd(nameof(admMovimientos.CIMPUESTO3),
+            datosMovimiento.TryAdd(nameof(admMovimientos.CPORCENTAJEIMPUESTO3),
                 movimiento.Impuestos.Impuesto3.Tasa.ToString(CultureInfo.InvariantCulture));
         }
 


### PR DESCRIPTION
Este PR corrige un error en `MovimientoExtensions.AddImpuestosToDictionary` donde no se estaba asignando la tasa del impuesto 1 y 2.