### PR TITLE
fix: Corrige bug en crear y actualizar direcciones de cliente

### DIFF
--- a/samples/Sdk.Extras.ConsoleApp/DependencyInjection.cs
+++ b/samples/Sdk.Extras.ConsoleApp/DependencyInjection.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Sdk.Extras.ConsoleApp.Direcciones;
 
 namespace Sdk.Extras.ConsoleApp;
 
@@ -31,6 +32,11 @@ public static class DependencyInjection
         // Conceptos
         serviceCollection.AddTransient<BuscarConceptosDocumentoConRepositorio>();
         serviceCollection.AddTransient<BuscarConceptosDocumentoDtoConRepositorio>();
+
+        // Direcciones
+        serviceCollection.AddTransient<ActualizarDireccionCliente>();
+        serviceCollection.AddTransient<BuscarDireccionCliente>();
+        serviceCollection.AddTransient<CrearDireccionCliente>();
 
         // Documentos
         serviceCollection.AddTransient<BuscarDocumentosConRepositorio>();

--- a/samples/Sdk.Extras.ConsoleApp/Direcciones/ActualizarDireccionCliente.cs
+++ b/samples/Sdk.Extras.ConsoleApp/Direcciones/ActualizarDireccionCliente.cs
@@ -1,0 +1,41 @@
+﻿using ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.Enums;
+using ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.Models;
+using ARSoftware.Contpaqi.Comercial.Sdk.DatosAbstractos;
+using ARSoftware.Contpaqi.Comercial.Sdk.Extras.Extensions;
+using ARSoftware.Contpaqi.Comercial.Sdk.Extras.Interfaces;
+
+namespace Sdk.Extras.ConsoleApp.Direcciones;
+
+public class ActualizarDireccionCliente
+{
+    private readonly IDireccionService _direccionService;
+
+    public ActualizarDireccionCliente(IDireccionService direccionService)
+    {
+        _direccionService = direccionService;
+    }
+
+    public void ActualizarFiscal()
+    {
+        var codigoCliente = "PRUEBA";
+
+        var direccion = new Direccion
+        {
+            TipoCatalogo = TipoCatalogoDireccion.Clientes,
+            Tipo = TipoDireccion.Fiscal,
+            Calle = "cALLE",
+            NumeroExterior = "1",
+            NumeroInterior = "1",
+            Colonia = "Colonia",
+            Ciudad = "Ciudad",
+            Estado = "Estado",
+            CodigoPostal = "123456",
+            Pais = "México"
+        };
+
+        tDireccion direccionSdk = direccion.ToSdkDireccion();
+        direccionSdk.cCodCteProv = codigoCliente;
+
+        _direccionService.Actualizar(direccionSdk);
+    }
+}

--- a/samples/Sdk.Extras.ConsoleApp/Direcciones/ActualizarDireccionCliente.cs
+++ b/samples/Sdk.Extras.ConsoleApp/Direcciones/ActualizarDireccionCliente.cs
@@ -6,7 +6,7 @@ using ARSoftware.Contpaqi.Comercial.Sdk.Extras.Interfaces;
 
 namespace Sdk.Extras.ConsoleApp.Direcciones;
 
-public class ActualizarDireccionCliente
+public sealed class ActualizarDireccionCliente
 {
     private readonly IDireccionService _direccionService;
 
@@ -23,7 +23,7 @@ public class ActualizarDireccionCliente
         {
             TipoCatalogo = TipoCatalogoDireccion.Clientes,
             Tipo = TipoDireccion.Fiscal,
-            Calle = "cALLE",
+            Calle = "Calle",
             NumeroExterior = "1",
             NumeroInterior = "1",
             Colonia = "Colonia",

--- a/samples/Sdk.Extras.ConsoleApp/Direcciones/BuscarDireccionCliente.cs
+++ b/samples/Sdk.Extras.ConsoleApp/Direcciones/BuscarDireccionCliente.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Sdk.Extras.ConsoleApp.Direcciones;
 
-public class BuscarDireccionCliente
+public sealed class BuscarDireccionCliente
 {
     private readonly IDireccionRepository<DireccionDto> _direccionRepository;
     private readonly ILogger<BuscarDireccionCliente> _logger;
@@ -19,8 +19,9 @@ public class BuscarDireccionCliente
     public void Buscar()
     {
         var codigoCliente = "PRUEBA";
+        var tipoDireccion = TipoDireccion.Fiscal;
 
-        DireccionDto? direccion = _direccionRepository.BuscarPorCliente(codigoCliente, TipoDireccion.Fiscal);
+        DireccionDto? direccion = _direccionRepository.BuscarPorCliente(codigoCliente, tipoDireccion);
 
         _logger.LogInformation("{@Direccion}", direccion);
     }

--- a/samples/Sdk.Extras.ConsoleApp/Direcciones/BuscarDireccionCliente.cs
+++ b/samples/Sdk.Extras.ConsoleApp/Direcciones/BuscarDireccionCliente.cs
@@ -1,0 +1,27 @@
+﻿using ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.Dtos;
+using ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.Enums;
+using ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace Sdk.Extras.ConsoleApp.Direcciones;
+
+public class BuscarDireccionCliente
+{
+    private readonly IDireccionRepository<DireccionDto> _direccionRepository;
+    private readonly ILogger<BuscarDireccionCliente> _logger;
+
+    public BuscarDireccionCliente(IDireccionRepository<DireccionDto> direccionRepository, ILogger<BuscarDireccionCliente> logger)
+    {
+        _direccionRepository = direccionRepository;
+        _logger = logger;
+    }
+
+    public void Buscar()
+    {
+        var codigoCliente = "PRUEBA";
+
+        DireccionDto? direccion = _direccionRepository.BuscarPorCliente(codigoCliente, TipoDireccion.Fiscal);
+
+        _logger.LogInformation("{@Direccion}", direccion);
+    }
+}

--- a/samples/Sdk.Extras.ConsoleApp/Direcciones/CrearDireccionCliente.cs
+++ b/samples/Sdk.Extras.ConsoleApp/Direcciones/CrearDireccionCliente.cs
@@ -1,0 +1,36 @@
+﻿using ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.Enums;
+using ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.Models;
+using ARSoftware.Contpaqi.Comercial.Sdk.Extras.Interfaces;
+
+namespace Sdk.Extras.ConsoleApp.Direcciones;
+
+public class CrearDireccionCliente
+{
+    private readonly IDireccionService _direccionService;
+
+    public CrearDireccionCliente(IDireccionService direccionService)
+    {
+        _direccionService = direccionService;
+    }
+
+    public int Crear()
+    {
+        var codigoCliente = "PRUEBA";
+
+        var direccion = new Direccion
+        {
+            TipoCatalogo = TipoCatalogoDireccion.Clientes,
+            Tipo = TipoDireccion.Fiscal,
+            Calle = "Calle",
+            NumeroExterior = "1",
+            NumeroInterior = "1",
+            Colonia = "Colonia",
+            Ciudad = "Ciudad",
+            Estado = "Estado",
+            CodigoPostal = "123456",
+            Pais = "México"
+        };
+
+        return _direccionService.Crear(codigoCliente, direccion);
+    }
+}

--- a/samples/Sdk.Extras.ConsoleApp/Direcciones/CrearDireccionCliente.cs
+++ b/samples/Sdk.Extras.ConsoleApp/Direcciones/CrearDireccionCliente.cs
@@ -4,7 +4,7 @@ using ARSoftware.Contpaqi.Comercial.Sdk.Extras.Interfaces;
 
 namespace Sdk.Extras.ConsoleApp.Direcciones;
 
-public class CrearDireccionCliente
+public sealed class CrearDireccionCliente
 {
     private readonly IDireccionService _direccionService;
 

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/Extensions/MapExtensions.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/Extensions/MapExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.Enums;
 using ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.Models;
 using ARSoftware.Contpaqi.Comercial.Sdk.DatosAbstractos;
 using ARSoftware.Contpaqi.Comercial.Sdk.Extras.Helpers;
@@ -144,7 +145,7 @@ public static class MapExtensions
         return new tDireccion
         {
             cTipoCatalogo = (int)direccion.TipoCatalogo,
-            cTipoDireccion = (int)direccion.Tipo,
+            cTipoDireccion = direccion.Tipo == TipoDireccion.Fiscal ? 1 : 2,
             cNombreCalle = direccion.Calle,
             cNumeroExterior = direccion.NumeroExterior,
             cNumeroInterior = direccion.NumeroInterior,

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/Services/DireccionService.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/Services/DireccionService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.Models;
 using ARSoftware.Contpaqi.Comercial.Sdk.Constantes;
 using ARSoftware.Contpaqi.Comercial.Sdk.DatosAbstractos;
@@ -25,6 +26,8 @@ public class DireccionService : IDireccionService
 
     public void Actualizar(int idDireccion, Dictionary<string, string> datosDireccion)
     {
+        if (!datosDireccion.Any()) return;
+
         _sdk.fPosPrimerDireccion().ToResultadoSdk(_sdk).ThrowIfError();
         string idDireccionDato = _sdk.LeeDatoDireccion(nameof(admDomicilios.CIDDIRECCION), SdkConstantes.kLongId);
         if (idDireccion == int.Parse(idDireccionDato))
@@ -68,6 +71,7 @@ public class DireccionService : IDireccionService
 
     public int Crear(string codigoClienteProveedor, Direccion direccion)
     {
+        _sdk.fBuscaCteProv(codigoClienteProveedor).ToResultadoSdk(_sdk).ThrowIfError();
         tDireccion sdkDireccion = direccion.ToSdkDireccion();
         sdkDireccion.cCodCteProv = codigoClienteProveedor;
         int nuevaDireccionId = Crear(sdkDireccion);


### PR DESCRIPTION
Este PR corrige un bug en donde no se podia crear o actualizar una direccion de envio. Este bug estaba ubicado en en metodo que convierte un objeto de tipo `Direccion` a un objeto de tipo `tDireccion`.

Tambien se agregaron ejemplos de como crear, actualizar, y consultar direcciones de cliente.

Closes #100