### PR TITLE
docs: Agrega ejemplo de como relacionar documentos cfdi

### DIFF
--- a/samples/Sdk.Extras.ConsoleApp/DependencyInjection.cs
+++ b/samples/Sdk.Extras.ConsoleApp/DependencyInjection.cs
@@ -48,6 +48,7 @@ public static class DependencyInjection
         serviceCollection.AddTransient<DesbloquearDocumento>();
         serviceCollection.AddTransient<EliminarDocumento>();
         serviceCollection.AddTransient<GenerarDocumentoDigitalDocumento>();
+        serviceCollection.AddTransient<RelacionarDocumento>();
         serviceCollection.AddTransient<SaldarDocumento>();
         serviceCollection.AddTransient<TimbrarDocumento>();
 

--- a/samples/Sdk.Extras.ConsoleApp/Documentos/RelacionarDocumento.cs
+++ b/samples/Sdk.Extras.ConsoleApp/Documentos/RelacionarDocumento.cs
@@ -1,0 +1,29 @@
+﻿using ARSoftware.Contpaqi.Comercial.Sdk.DatosAbstractos;
+using ARSoftware.Contpaqi.Comercial.Sdk.Extras.Interfaces;
+
+namespace Sdk.Extras.ConsoleApp;
+
+public sealed class RelacionarDocumento
+{
+    private readonly IDocumentoService _documentoService;
+
+    public RelacionarDocumento(IDocumentoService documentoService)
+    {
+        _documentoService = documentoService;
+    }
+
+    public void RelacionPorLlave()
+    {
+        var documento = new tLlaveDoc { aCodConcepto = "PRUEBAFACTURA", aSerie = "PRUEBA", aFolio = 1 };
+        var documentoARelacionar = new tLlaveDoc { aCodConcepto = "PRUEBAFACTURA", aSerie = "PRUEBA", aFolio = 2 };
+
+        _documentoService.RelacionarDocumentos(documento, "01", documentoARelacionar);
+    }
+
+    public void RelacionPorUuid()
+    {
+        var documento = new tLlaveDoc { aCodConcepto = "PRUEBAFACTURA", aSerie = "PRUEBA", aFolio = 1 };
+
+        _documentoService.RelacionarDocumentos(documento, "03", "51F58A42-3827-49A3-A1E5-54CADF80F9C6");
+    }
+}


### PR DESCRIPTION
Este PR agrega ejemplos de como relacionar documentos de tipo CFDI por llave y por UUID.

```csharp
public void RelacionPorLlave()
{
    var documento = new tLlaveDoc { aCodConcepto = "PRUEBAFACTURA", aSerie = "PRUEBA", aFolio = 1 };
    var documentoARelacionar = new tLlaveDoc { aCodConcepto = "PRUEBAFACTURA", aSerie = "PRUEBA", aFolio = 2 };

    _documentoService.RelacionarDocumentos(documento, "01", documentoARelacionar);
}

public void RelacionPorUuid()
{
    var documento = new tLlaveDoc { aCodConcepto = "PRUEBAFACTURA", aSerie = "PRUEBA", aFolio = 1 };

    _documentoService.RelacionarDocumentos(documento, "03", "51F58A42-3827-49A3-A1E5-54CADF80F9C6");
}
```