### PR TITLE
Mapea las bases de datos de Comercial v9.2.1

### DIFF
--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
@@ -27,10 +27,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<ProjectReference Include="..\ARSoftware.Contpaqi.Comercial.Sdk.Abstractions\ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj" />
 		<ProjectReference Include="..\ARSoftware.Contpaqi.Comercial.Sdk\ARSoftware.Contpaqi.Comercial.Sdk.csproj" />
 		<ProjectReference Include="..\ARSoftware.Contpaqi.Comercial.Sql.Models\ARSoftware.Contpaqi.Comercial.Sql.Models.csproj" />

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admParametros.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admParametros.cs
@@ -426,4 +426,6 @@ public partial class admParametros
     public string? CREFRESHTOKENCN { get; set; }
 
     public string? CURLWSTORE { get; set; }
+
+    public string CLEYENDON { get; set; } = null!;
 }

--- a/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
@@ -28,7 +28,7 @@
 	<ItemGroup>
 		<PackageReference Include="Ardalis.Specification" Version="8.0.0" />
 		<PackageReference Include="Ardalis.Specification.EntityFrameworkCore" Version="8.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql/Contexts/ContpaqiComercialEmpresaDbContext.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql/Contexts/ContpaqiComercialEmpresaDbContext.cs
@@ -2246,6 +2246,9 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
                 .HasMaxLength(60)
                 .IsUnicode(false)
                 .HasDefaultValue("");
+            entity.Property(e => e.CLEYENDON)
+                .IsUnicode(false)
+                .HasDefaultValue("");
             entity.Property(e => e.CLEYENDON1)
                 .HasMaxLength(253)
                 .IsUnicode(false)

--- a/src/Sql.MigrationsStartupProject/Sql.MigrationsStartupProject.csproj
+++ b/src/Sql.MigrationsStartupProject/Sql.MigrationsStartupProject.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Se actualizan las bases de datos de Comercial v9.2.1.

Solo las bases de datos de empresas tuvieron cambios.
Se actualizo la version de EF a la 8.0.0 para ser mas compatible con consumidores.